### PR TITLE
Implemented provisional standings feature.

### DIFF
--- a/ChallengeBoard/Controllers/BoardsController.cs
+++ b/ChallengeBoard/Controllers/BoardsController.cs
@@ -328,7 +328,7 @@ namespace ChallengeBoard.Controllers
         //
         // Get: /Boards/Standings/5
 
-        public ActionResult Standings(int id = 0, int page = 1)
+        public ActionResult Standings(int id = 0, int page = 1, bool official = true)
         {
             if (page < 1) page = 1;
 
@@ -336,6 +336,55 @@ namespace ChallengeBoard.Controllers
 
             if (existingBoard == null)
                 return View("BoardNotFound");
+
+            if (!official)
+            {
+                // All unresolved matches for this challenge board.
+                var unresolvedMatches = _repository.GetUnresolvedMatchesByBoardId(id);
+
+                var deltas = new Dictionary<int, Dictionary<string, int>>();
+
+                // Traverse the pending queue in order and build competitor deltas dictionary
+                foreach (var match in unresolvedMatches.OrderBy(x => x.VerificationDeadline))
+                {
+                    if (!deltas.ContainsKey(match.Winner.CompetitorId))
+                        deltas.Add(match.Winner.CompetitorId, new Dictionary<string, int>{{"rating", 0},{"wins", 0},{"loses", 0},{"ties", 0},{"streak", 0}});
+
+                    if (!deltas.ContainsKey(match.Loser.CompetitorId))
+                        deltas.Add(match.Loser.CompetitorId, new Dictionary<string, int>{{"rating", 0},{"wins", 0},{"loses", 0},{"ties", 0},{"streak", 0}});
+
+                    deltas[match.Winner.CompetitorId]["rating"] += match.WinnerRatingDelta;
+                    deltas[match.Loser.CompetitorId]["rating"] += match.LoserRatingDelta;
+
+                    if (match.Tied)
+                    {
+                        deltas[match.Winner.CompetitorId]["ties"] += 1;
+                        deltas[match.Loser.CompetitorId]["ties"] += 1;
+                        deltas[match.Winner.CompetitorId]["streak"] = 0;
+                    }
+                    else
+                    {
+                        deltas[match.Loser.CompetitorId]["loses"] += 1;
+                        deltas[match.Loser.CompetitorId]["streak"] = 0;
+
+                        deltas[match.Winner.CompetitorId]["wins"] += 1;
+                        deltas[match.Winner.CompetitorId]["streak"] += 1;
+                    }
+                }
+
+                // Traverse existingBoard.Competitors and apply deltas gathered in the dictionary
+                foreach (var competitor in existingBoard.Competitors)
+                {
+                    if (deltas.ContainsKey(competitor.CompetitorId))
+                    {
+                        competitor.Rating += deltas[competitor.CompetitorId]["rating"];
+                        competitor.Wins += deltas[competitor.CompetitorId]["wins"];
+                        competitor.Loses += deltas[competitor.CompetitorId]["loses"];
+                        competitor.Ties += deltas[competitor.CompetitorId]["ties"];
+                        competitor.Streak += deltas[competitor.CompetitorId]["streak"];
+                    }
+                }
+            }
 
             // Unranked players get 0 rating.
             existingBoard.Competitors.Where(c => c.MatchesPlayed == 0).ToList().ForEach(c => c.Rating = 0);
@@ -346,5 +395,14 @@ namespace ChallengeBoard.Controllers
                 Standings = existingBoard.Competitors.Active().OrderByDescending(c => c.Rating).ToPagedList(page, PageLimits.Standings)
             });
         }
+
+        //
+        // Get: /Boards/ProvisionalStandings/5
+
+        public ActionResult ProvisionalStandings(int id = 0, int page = 1)
+        {
+            return Standings(id, page, false);
+        }
+
     }
 }

--- a/ChallengeBoard/Views/Shared/_BoardNav.cshtml
+++ b/ChallengeBoard/Views/Shared/_BoardNav.cshtml
@@ -10,6 +10,7 @@
     <div class="pull-left">
         <ul class="nav nav-pills">
             @Html.MenuLink("Standings", "Standings", "Boards", new { id = Model.BoardId }, null)
+            @Html.MenuLink("Provisional Standings", "ProvisionalStandings", "Boards", new { id = Model.BoardId }, null)
             @Html.MenuLink("Information", "Details", "Boards", new { id = Model.BoardId }, null)
             @Html.MenuLink("Match Activity", "List", "Matches", new { boardId = Model.BoardId }, null)
             @Html.MenuLink("Report a Match", "Create", "Matches", new { boardId = Model.BoardId }, null)


### PR DESCRIPTION
- added "Provisional Standings" button to the board nav bar
- added a route to handle the button
- the route logic applies the match backlog without a db commit, forwards to usual standings view

This feature let's people inspect current "real" standings. The official standings usually do not reflect the truth, since usually a lot is happening in the pending queue.