### PR TITLE
Prevent body overflow on mobile

### DIFF
--- a/ChallengeBoard/Content/bootstrap-ext.css
+++ b/ChallengeBoard/Content/bootstrap-ext.css
@@ -441,3 +441,7 @@ ol li {
 #footer {
     height: 70px;
 }
+
+.hero-unit h1 {
+    word-wrap: break-word;
+}


### PR DESCRIPTION
Allow h1 to break so as to prevent body overflow (visible on mobile).
